### PR TITLE
Fix typos in comments and log output

### DIFF
--- a/greeting/greeting.go
+++ b/greeting/greeting.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 // greeting is the function's core logic.
-// It resoponses "Hiya!" and calls the next function if NEXT_ENDPOINT is set.
+// It responses "Hiya!" and calls the next function if NEXT_ENDPOINT is set.
 func greeting(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hiya!")
 
@@ -40,7 +40,7 @@ func greeting(w http.ResponseWriter, r *http.Request) {
 func greetNext(ctx context.Context) error {
 	next := os.Getenv("NEXT_ENDPOINT")
 	if next == "" {
-		log.Println("I have no freinds :(")
+		log.Println("I have no friends :(")
 		return nil
 	}
 

--- a/greeting/instrumentor.go
+++ b/greeting/instrumentor.go
@@ -34,7 +34,7 @@ func InstrumentedHandler(functionName string, function HttpHandler, flusher Flus
 
 		// NOTE: ForceFlush() may extend the function's duration. It must be used carefully.
 		//       If ForceFlush() is not called, spans are send on background.
-		//       Backgraound tasks are not recommended in Cloud Functions. Span data sometimes get lost.
+		//       Background tasks are not recommended in Cloud Functions. Span data sometimes get lost.
 		err := flusher.ForceFlush(r.Context())
 		if err != nil {
 			log.Printf("failed to flush spans: %v", err)


### PR DESCRIPTION
素晴らしいブログをありがとうございます!

# What's this? (AI-generated)

Corrected a few misspelled words in the comments and log output in the 'greeting' and 'instrumentor' files.